### PR TITLE
fix: update client version and make it configurable

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,13 +10,6 @@ app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
 app.use(morgan(process.env.MORGAN_FORMAT ?? 'tiny'));
 
-app.use((req, res, next) => {
-  if (!req.headers.authorization && process.env.CURSOR_TOKEN) {
-    req.headers.authorization = `Bearer ${process.env.CURSOR_TOKEN}`;
-  }
-  next();
-});
-
 app.use("/", routes)
 
 app.listen(config.port, () => {

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,13 @@ app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
 app.use(morgan(process.env.MORGAN_FORMAT ?? 'tiny'));
 
+app.use((req, res, next) => {
+  if (!req.headers.authorization && process.env.CURSOR_TOKEN) {
+    req.headers.authorization = `Bearer ${process.env.CURSOR_TOKEN}`;
+  }
+  next();
+});
+
 app.use("/", routes)
 
 app.listen(config.port, () => {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,5 +1,6 @@
 module.exports = {
     port: process.env.PORT || 3010,
+    cursorClientVersion: process.env.CURSOR_CLIENT_VERSION || '2.6.21',
     proxy:{
         enabled: false,
         url: 'http://127.0.0.1:7890',

--- a/src/routes/v1.js
+++ b/src/routes/v1.js
@@ -20,7 +20,7 @@ router.get("/models", async (req, res) => {
 
     const cursorChecksum = req.headers['x-cursor-checksum'] 
       ?? generateCursorChecksum(authToken.trim());
-    const cursorClientVersion = "0.48.7"
+    const cursorClientVersion = config.cursorClientVersion
 
     const availableModelsResponse = await fetch("https://api2.cursor.sh/aiserver.v1.AiService/AvailableModels", {
       method: 'POST',
@@ -92,7 +92,7 @@ router.post('/chat/completions', async (req, res) => {
 
     const sessionid = uuidv5(authToken,  uuidv5.DNS);
     const clientKey = generateHashed64Hex(authToken)
-    const cursorClientVersion = "0.48.7"
+    const cursorClientVersion = config.cursorClientVersion
     const cursorConfigVersion = uuidv4();
 
     // Request the AvailableModels before StreamChat.


### PR DESCRIPTION
Update hardcoded `cursorClientVersion` from `0.48.7` to `2.6.21` and make it configurable via `CURSOR_CLIENT_VERSION` env var.

The old version is rejected by Cursor's API.